### PR TITLE
Adopt to pytest 7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     py_modules=["pytest_black"],
     python_requires=">=3.5",
     install_requires=[
-        "pytest>=3.5.0",
-        'black>=22.1.0"',
+        "black>=22.1.0",
+        "pytest>=7.0.0",
         "toml",
     ],
     use_scm_version=True,


### PR DESCRIPTION
pytest 7.x deprecated few things and also dropped support for python 2.7

This change also add testing on python 3.9 and 3.10, and run flake8 on latest python in CI

Port of shopkeep/pytest-black#61, adjusting for modified CI