### PR TITLE
Add --no-black flag

### DIFF
--- a/pytest_black.py
+++ b/pytest_black.py
@@ -18,11 +18,14 @@ def pytest_addoption(parser):
     group.addoption(
         "--black", action="store_true", help="enable format checking with black"
     )
+    group.addoption(
+        "--no-black", action="store_true", default=False, help="disable running black"
+    )
 
 
 def pytest_collect_file(file_path, path, parent):
     config = parent.config
-    if config.option.black and path.ext == ".py":
+    if config.option.black and not config.option.no_black and path.ext == ".py":
         return BlackFile.from_parent(parent, path=file_path)
 
 

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -24,6 +24,19 @@ def test_fail(testdir):
     result.assert_outcomes(failed=1)
 
 
+def test_disable(testdir):
+    """Assert no formatting check when black is disabled
+    """
+    testdir.makepyfile(
+        """
+        def hello():
+            print('Hello, world')
+    """
+    )
+    result = testdir.runpytest("--black", "--no-black")
+    result.assert_outcomes(failed=0, passed=0)
+
+
 def test_pass(testdir):
     """Assert test passes when no formatting issues are found
     """


### PR DESCRIPTION
This fixes https://github.com/shopkeep/pytest-black/issues/51 from before the fork.

I just started learning Python so I appreciate help with the testing part, not sure if checking passed and failed at the same time is right.